### PR TITLE
Retain trailing backslash

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function getBaseUrlAndPaths(baseDir) {
 }
 
 function getExpectedPath(absolutePath, baseUrl, importPrefixToAlias, onlyPathAliases, onlyAbsoluteImports) {
-  const relativeToBasePath = path.relative(baseUrl, absolutePath);
+  const relativeToBasePath = path.relative(baseUrl, absolutePath) + (absolutePath.endsWith('/') ? '/' : '');
   if (!onlyAbsoluteImports) {
     for (let prefix of Object.keys(importPrefixToAlias)) {
       const aliasPath = importPrefixToAlias[prefix];


### PR DESCRIPTION
A trailing backslash can be used to disambiguate a file from a directory.

Let's assume the following structure:
```
foo.ts
foo/
├─ index.ts
bar/
├─ bar.ts
```
where `bar/bar.ts` is:
```typescript
import { Foo } from "../foo"   // → foo.ts
import { Foo } from "../foo/"  // → foo/index.ts
```

**Expected**
```typescript
import { Foo } from "foo"
import { Foo } from "foo/"
```

**Actual**
```typescript
import { Foo } from "foo"
import { Foo } from "foo"
```
